### PR TITLE
Changed "minSdk" in app/build.gradle.kts to 30

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId = "com.mindflakes.quickbayscan"
-        minSdk = 33
+        minSdk = 30
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"


### PR DESCRIPTION
I have a Samsung Galaxy Note 10, which uses Android 11 (API level 30). I wanted to see if changing "minSdk" in app/build.gradle.kts to 30 would work, and I was able to run the app using Android Studio on my phone.